### PR TITLE
Fix building DTBs when /bin/sh is not bash

### DIFF
--- a/disk/part_efi.c
+++ b/disk/part_efi.c
@@ -854,6 +854,7 @@ int gpt_verify_partitions(struct blk_desc *dev_desc,
 			return -1;
 		}
 
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 		/* Check if GPT and ENV partition names match */
 		gpt_convert_efi_name_to_char(efi_str, gpt_e[i].partition_name,
 					     PARTNAME_SZ + 1);

--- a/drivers/usb/gadget/composite.c
+++ b/drivers/usb/gadget/composite.c
@@ -627,6 +627,8 @@ static int get_string(struct usb_composite_dev *cdev,
 		s->bDescriptorType = USB_DT_STRING;
 
 		sp = composite->strings;
+
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 		if (sp)
 			collect_langs(sp, s->wData);
 

--- a/drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c
+++ b/drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c
@@ -1287,6 +1287,7 @@ static void dwc2_ep0_setup(struct dwc2_udc *dev)
 	/* Nuke all previous transfers */
 	nuke(ep, -EPROTO);
 
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 	/* read control req from fifo (8 bytes) */
 	dwc2_fifo_read(ep, (u32 *)usb_ctrl, 8);
 

--- a/include/linux/log2.h
+++ b/include/linux/log2.h
@@ -15,7 +15,7 @@
 /*
  * deal with unrepresentable constant logarithms
  */
-extern __attribute__((const, noreturn))
+extern __attribute__((noreturn))
 int ____ilog2_NaN(void);
 
 /*

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -236,6 +236,7 @@ void uuid_bin_to_str(unsigned char *uuid_bin, char *uuid_str, int str_format)
 void gen_rand_uuid(unsigned char *uuid_bin)
 {
 	struct uuid uuid;
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 	unsigned int *ptr = (unsigned int *)&uuid;
 	int i;
 

--- a/net/bootp.c
+++ b/net/bootp.c
@@ -120,6 +120,8 @@ static int check_reply_packet(uchar *pkt, unsigned dest, unsigned src,
 {
 	struct bootp_hdr *bp = (struct bootp_hdr *)pkt;
 	int retval = 0;
+       
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 
 	if (dest != PORT_BOOTPC || src != PORT_BOOTPS)
 		retval = -1;
@@ -789,6 +791,7 @@ void bootp_request(void)
 	bootp_id += get_timer(0);
 	bootp_id = htonl(bootp_id);
 	bootp_add_id(bootp_id);
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 	net_copy_u32(&bp->bp_id, &bootp_id);
 
 	/*

--- a/net/nfs.c
+++ b/net/nfs.c
@@ -196,6 +196,8 @@ static void rpc_req(int rpc_prog, int rpc_proc, uint32_t *data, int datalen)
 		rpc_pkt.u.call.vers = htonl(2);	/* portmapper is version 2 */
 	}
 	rpc_pkt.u.call.proc = htonl(rpc_proc);
+
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 	p = (uint32_t *)&(rpc_pkt.u.call.data);
 
 	if (datalen)

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -308,7 +308,7 @@ quiet_cmd_dtc = DTC     $@
 # Modified for U-Boot
 # Bring in any U-Boot-specific include at the end of the file
 cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
-	(cat $<; $(if $(u_boot_dtsi),echo '\#include "$(u_boot_dtsi)"')) > $(pre-tmp); \
+	(cat $<; $(if $(u_boot_dtsi),echo '#include "$(u_boot_dtsi)"')) > $(pre-tmp); \
 	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $(pre-tmp) ; \
 	$(DTC) -O dtb -o $@ -b 0 \
 		-i $(dir $<) $(DTC_FLAGS) \

--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -631,7 +631,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/tools/rockchip/boot_merger.c
+++ b/tools/rockchip/boot_merger.c
@@ -887,10 +887,10 @@ end:
 static inline void wide2str(const uint16_t *wide, char *str, int len)
 {
 	int i;
-	for (i = 0; i < len; i++) {
+	for (i = 0; i < len - 1; i++) {
 		str[i] = (char)(wide[i] & 0xFF);
 	}
-	str[len] = 0;
+	str[len - 1] = 0;
 }
 
 static bool unpackEntry(rk_boot_entry *entry, const char *name, FILE *inFile)


### PR DESCRIPTION
The code to include $(u_boot_dtsi) included a backslash at the start
of the line if /bin/sh was POSIX-conforming (e.g., dash) in its
quoting rules.